### PR TITLE
Use boolean formatter, bool not exists

### DIFF
--- a/views/cron-job/index.php
+++ b/views/cron-job/index.php
@@ -41,7 +41,7 @@ $this->params['breadcrumbs'][] = $this->title;
                 [
                     'class' => '\kartik\grid\DataColumn',
                     'attribute' => 'active',
-                    'format' => 'bool',
+                    'format' => 'boolean',
                 ],
                 [
                     'class' => '\kartik\grid\DataColumn',
@@ -64,7 +64,7 @@ $this->params['breadcrumbs'][] = $this->title;
                         return $job->last->exit_code == 0 ? true : false;
                     },
                     'label' => Yii::t('vbt-cron', 'Success'),
-                    'format' => 'bool',
+                    'format' => 'boolean',
                 ],
                 [
                     'class' => 'kartik\grid\ActionColumn',


### PR DESCRIPTION
Hello 

Thank you for your nice extension.

`Unknown format type: bool`

In the actual version I get this error on index cause the formatter now is boolean.